### PR TITLE
[CI] Changed triton-nightly to --pre triton

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -8,7 +8,7 @@ variables:
   value: venv
 
 # Run CI when something pushed to master
-# trigger: [ master ]
+trigger: none
 # Run CI when a PR is created or updated from master
 pr:
 - master

--- a/.ci/build-wheels.yml
+++ b/.ci/build-wheels.yml
@@ -17,7 +17,7 @@ jobs:
         pip3 install twine
       displayName: Install dependencies
     - bash: |
-        sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py
+        #sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py
         sed -i -r "s/version\=\"(.*)\"/version=\"\1-dev`date '+%Y%m%d'`\"/g" python/setup.py
         echo "" >> python/setup.cfg
         echo "[build_ext]" >> python/setup.cfg

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -10,7 +10,7 @@ You can install the latest nightly release of Triton from pip:
 
 .. code-block:: bash
   
-      pip install triton-nightly
+      pip install -U --pre triton
 
 
 --------------

--- a/python/setup.py
+++ b/python/setup.py
@@ -90,17 +90,14 @@ class CMakeBuild(build_ext):
 
 setup(
     name="triton",
-    version="1.0.0-dev20210323",
+    version="1.0.0",
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",
     long_description="",
     packages=["triton", "triton/_C", "triton/ops", "triton/ops/blocksparse"],
     install_requires=["numpy", "torch"],
-    package_data={
-        "triton/ops": ["*.c"],
-        "triton/ops/blocksparse": ["*.c"]
-    },
+    package_data={"triton/ops": ["*.c"], "triton/ops/blocksparse": ["*.c"]},
     include_package_data=True,
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={"build_ext": CMakeBuild},

--- a/python/setup.py
+++ b/python/setup.py
@@ -90,7 +90,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name="triton",
-    version="1.0.0",
+    version="1.0.0-dev20210323",
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",


### PR DESCRIPTION
The solution proposed in the previous #77 can create namespace conflicts when `triton` and `triton-nightly` have both been pip installed. Therefore, this PR is moving nightly releases to pre-releases in the main triton index.