### PR TITLE
Allow triton.code_gen.Binary to print asm.

### DIFF
--- a/lib/codegen/selection/generator.cc
+++ b/lib/codegen/selection/generator.cc
@@ -817,9 +817,9 @@ void generator::visit_mma884(ir::dot_inst* C, ir::value *A, ir::value *B, ir::va
   // update accumulators
   unsigned num_m = layout_c->rep(0) * shape_c[0] / layout_c->spt(0);
   unsigned num_n = layout_c->rep(1) * shape_c[1] / layout_c->spt(1);
+  for(unsigned K = 0; K < NK; K += 4)
   for(unsigned m = 0; m < num_m/2; m++)
-  for(unsigned n = 0; n < num_n/2; n++)
-  for(unsigned K = 0; K < NK; K += 4){
+  for(unsigned n = 0; n < num_n/2; n++) {
     if(has.find({m, K}) == has.end()){
       Value* ptra = ptr_a[(is_a_row ? K/4 : m) % num_ptr_a];
       int step_am = is_a_row ? m : m / (num_ptr_a)*(num_ptr_a);

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -7,6 +7,7 @@
 #include "triton/ir/enums.h"
 #include "triton/ir/function.h"
 #include "triton/ir/module.h"
+#include "triton/ir/print.h"
 #include <optional>
 #include <pybind11/buffer_info.h>
 #include <pybind11/functional.h>
@@ -78,7 +79,9 @@ void init_triton_codegen(py::module &&m) {
         drv::kernel *ker;
         size_t shared_mem;
         triton::codegen::add_passes_to_emit_bin(ir, dev, num_warps, mod, ker, shared_mem);
-        return std::make_tuple(mod, ker, shared_mem);
+        std::stringstream ss;
+        ir::print(ir, ss);
+        return std::make_tuple(mod, ker, shared_mem, ss.str());
       },
       py::return_value_policy::take_ownership);
 }

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -396,7 +396,7 @@ class Binary:
         self.num_warps = num_warps
 
     def asm(self, mode):
-        if mode == 'ir':
+        if mode == 'ttir':
             return self.ir_asm
         if mode == 'ptx':
             return self.module.ptx()

--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -54,10 +54,10 @@ def add(x, y):
     #  - torch.tensor objects are implicitly converted to pointers to their first element.
     #  - `triton.jit`'ed functions can be subscripted with a launch grid to obtain a callable GPU kernel
     #  - don't forget to pass meta-parameters as keywords arguments
-    kernel = _add[grid](x, y, z, N, BLOCK=1024)
+    _add[grid](x, y, z, N, BLOCK=1024)
     # We return a handle to z but, since `torch.cuda.synchronize()` hasn't been called, the kernel is still
     # running asynchronously.
-    return z, kernel
+    return z
 
 
 # %%
@@ -68,15 +68,10 @@ size = 98432
 x = torch.rand(size, device='cuda')
 y = torch.rand(size, device='cuda')
 za = x + y
-zb, kernel = add(x, y)
+zb = add(x, y)
 print(za)
 print(zb)
 print(f'The maximum difference between torch and triton is ' f'{torch.max(torch.abs(za - zb))}')
-
-# print asm
-# print(kernel.asm('ir'))
-# print(kernel.asm('ptx'))
-# print(kernel.asm('llir'))
 
 # %%
 # Seems like we're good to go!

--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -54,10 +54,10 @@ def add(x, y):
     #  - torch.tensor objects are implicitly converted to pointers to their first element.
     #  - `triton.jit`'ed functions can be subscripted with a launch grid to obtain a callable GPU kernel
     #  - don't forget to pass meta-parameters as keywords arguments
-    _add[grid](x, y, z, N, BLOCK=1024)
+    kernel = _add[grid](x, y, z, N, BLOCK=1024)
     # We return a handle to z but, since `torch.cuda.synchronize()` hasn't been called, the kernel is still
     # running asynchronously.
-    return z
+    return z, kernel
 
 
 # %%
@@ -68,10 +68,15 @@ size = 98432
 x = torch.rand(size, device='cuda')
 y = torch.rand(size, device='cuda')
 za = x + y
-zb = add(x, y)
+zb, kernel = add(x, y)
 print(za)
 print(zb)
 print(f'The maximum difference between torch and triton is ' f'{torch.max(torch.abs(za - zb))}')
+
+# print asm
+# print(kernel.asm('ir'))
+# print(kernel.asm('ptx'))
+# print(kernel.asm('llir'))
 
 # %%
 # Seems like we're good to go!


### PR DESCRIPTION
An example can be found in triton/python/tutorical/01-vector-add.py

```python
print(kernel.asm('ptx'))
```