### PR TITLE
Fix variable referenced before assignment error in sparse matmul backward

### DIFF
--- a/python/triton/ops/blocksparse/matmul.py
+++ b/python/triton/ops/blocksparse/matmul.py
@@ -560,7 +560,9 @@ class _matmul(torch.autograd.Function):
     def backward(ctx, dc):
         # saved for backward
         a, b = ctx.saved_tensors
+        da, db = None, None
         mode = ctx.mode
+
         # gradients w.r.t. a
         if ctx.needs_input_grad[0]:
             mode_da = mode[1] + mode[0] + mode[2]


### PR DESCRIPTION
In the backward pass for the blocksparse matmul op, a 'variable referenced before assignment' error would occur whenever either the A or B tensors don't need input grad. This PR fixes that crash.