### PR TITLE
Fix crash in sparse matmul for tensors w/ less than 4 dims

### DIFF
--- a/python/triton/ops/blocksparse/matmul.py
+++ b/python/triton/ops/blocksparse/matmul.py
@@ -560,7 +560,9 @@ class _matmul(torch.autograd.Function):
     def backward(ctx, dc):
         # saved for backward
         a, b = ctx.saved_tensors
+        da, db = None, None
         mode = ctx.mode
+
         # gradients w.r.t. a
         if ctx.needs_input_grad[0]:
             mode_da = mode[1] + mode[0] + mode[2]


### PR DESCRIPTION
The blocksparse matmul op seems to have been intended to work for tensors with less than 3 or 4 dimensions, since there's a `_pad_shape` function made explicitly to unsqueeze the input tensors to work with the kernel. But this `_pad_shape` function only padded sparse tensors up to 3 dimensions, while the lookup table-creating functions and kernel itself actually assume that all input tensors always have 4 dimensions. This caused a crash whenever a 3-dimensional sparse tensor was used as an input.

This PR fixes the crash by simply changing `_pad_shape` to always pad tensors to 4 dimensions. Also, I removed some local variables that my IDE said were not being used by anything, and after removing them the code still seems to work as expected.