### PR TITLE
[CODEGEN] Performance improvement on A100

### DIFF
--- a/include/triton/codegen/analysis/layout.h
+++ b/include/triton/codegen/analysis/layout.h
@@ -217,7 +217,8 @@ public:
   data_layout* get(size_t id)                                 { return layouts_.at(id); }
   data_layout* get(ir::value *v)                              { return get(layout_of(v));}
   std::map<size_t, data_layout*> &get_all()                   { return layouts_; }
-  size_t tmp(ir::instruction* i)                              { return tmp_.at((ir::value*)i);}
+  bool has_tmp(ir::value* i)                                  { return tmp_.find(i) != tmp_.end(); }
+  int tmp(ir::value* i)                                       { return tmp_.at(i);}
 
   // execution
   void run(ir::module &mod);

--- a/include/triton/codegen/analysis/layout.h
+++ b/include/triton/codegen/analysis/layout.h
@@ -141,10 +141,19 @@ struct double_buffer_info_t {
   ir::phi_node* phi;
 };
 
+struct N_buffer_info_t {
+  std::vector<ir::value*> firsts; // not necessarily ordered as input order
+  ir::value* latch;
+  ir::phi_node* phi;
+  std::map<ir::value*, int> firsts_idx;
+};
+
+// abstract for dot and coresponding smem values
 class shared_layout: public data_layout {
 private:
   static bool is_loop_latch(ir::phi_node *phi, ir::instruction *terminator);
   static void extract_double_bufferable(ir::value *v, std::shared_ptr<double_buffer_info_t>& res);
+  static void extract_N_bufferable(ir::value *v, std::shared_ptr<N_buffer_info_t>& res);
 
 public:
   shared_layout(data_layout *arg,
@@ -158,6 +167,10 @@ public:
   size_t get_size()                         { return size_; }
   ir::type* get_type()                      { return ty_; }
   double_buffer_info_t* get_double_buffer() { return double_buffer_.get(); }
+  N_buffer_info_t* get_N_buffer()           { return N_buffer_.get(); }
+  int get_num_stages() const;
+  size_t get_per_stage_size() const         { return size_ / get_num_stages(); }
+  size_t get_per_stage_elements() const;
   size_t get_num_per_phase()                { return num_per_phase_; }
   ir::value* hmma_dot_a()                      { return hmma_dot_a_; }
   ir::value* hmma_dot_b()                      { return hmma_dot_b_; }
@@ -169,6 +182,7 @@ private:
   size_t size_;
   ir::type *ty_;
   std::shared_ptr<double_buffer_info_t> double_buffer_;
+  std::shared_ptr<N_buffer_info_t>      N_buffer_;
   size_t num_per_phase_;
   ir::value* hmma_dot_a_;
   ir::value* hmma_dot_b_;

--- a/include/triton/codegen/pass.h
+++ b/include/triton/codegen/pass.h
@@ -21,7 +21,7 @@ namespace codegen{
 
 // TODO:
 // There should be a proper pass manager there!
-void add_passes_to_emit_bin(ir::module &ir, driver::device* dev, int num_warps,
+void add_passes_to_emit_bin(ir::module &ir, driver::device* dev, int num_warps, int num_stages,
                             driver::module*& mod, driver::kernel*& ker, size_t& shared_mem);
 
 

--- a/include/triton/codegen/selection/generator.h
+++ b/include/triton/codegen/selection/generator.h
@@ -223,6 +223,10 @@ private:
   std::map<ir::value*, Value*> shoffs_;
   std::map<ir::value*, std::vector<indices_t>> idxs_;
   std::map<ir::value*, std::map<indices_t, Value*>> vals_;
+  /// idx for multi-stage pipeline
+  std::map<analysis::data_layout*, Value*> read_smem_idx_;
+  std::map<analysis::data_layout*, Value*> write_smem_idx_;
+  
   /// triton bb -> llvm bb
   std::map<ir::value*, BasicBlock *> bbs_;
   std::map<ir::value*, std::vector<int>> ords_;

--- a/include/triton/codegen/transform/membar.h
+++ b/include/triton/codegen/transform/membar.h
@@ -31,6 +31,8 @@ class cts;
 
 namespace transform{
 
+class prefetch;
+
 class membar {
 private:
   typedef std::pair<unsigned, unsigned> interval_t;
@@ -39,13 +41,15 @@ private:
 
 private:
   bool intersect(const val_set_t &X, const val_set_t &Y);
+  bool check_safe_war(ir::instruction* i);
   int group_of(triton::ir::value *i, std::vector<triton::ir::value *> &async_write);
   val_set_t intersect_with(const val_set_t& as, const val_set_t& bs);
   void transfer(ir::basic_block *block, val_vec_t &async_write, val_set_t &sync_write, val_set_t &sync_read,
                 std::set<triton::ir::value *> &safe_war, bool &inserted, ir::builder &builder);
 
 public:
-  membar(analysis::liveness *liveness, analysis::layouts *layouts, analysis::allocation *alloc, target* tgt):
+  membar(analysis::liveness *liveness, analysis::layouts *layouts, analysis::allocation *alloc, 
+         transform::prefetch *prefetch_, target* tgt):
     liveness_(liveness), layouts_(layouts), alloc_(alloc), tgt_(tgt) {}
   void run(ir::module &mod);
 
@@ -53,6 +57,7 @@ private:
   analysis::liveness *liveness_;
   analysis::layouts *layouts_;
   analysis::allocation *alloc_;
+  transform::prefetch *prefetch_;
 
   target* tgt_;
 };

--- a/include/triton/codegen/transform/membar.h
+++ b/include/triton/codegen/transform/membar.h
@@ -26,6 +26,7 @@ class allocation;
 class liveness;
 class layouts;
 class cts;
+class shared_layout;
 
 }
 
@@ -43,6 +44,7 @@ private:
   bool intersect(const val_set_t &X, const val_set_t &Y);
   bool check_safe_war(ir::instruction* i);
   int group_of(triton::ir::value *i, std::vector<triton::ir::value *> &async_write);
+  bool intersect_with(analysis::shared_layout* a_layout, analysis::shared_layout* b_layout);
   val_set_t intersect_with(const val_set_t& as, const val_set_t& bs);
   void transfer(ir::basic_block *block, val_vec_t &async_write, val_set_t &sync_write, val_set_t &sync_read,
                 std::set<triton::ir::value *> &safe_war, bool &inserted, ir::builder &builder);

--- a/include/triton/codegen/transform/pipeline.h
+++ b/include/triton/codegen/transform/pipeline.h
@@ -14,11 +14,13 @@ namespace transform {
 
 class pipeline {
 public:
-  pipeline(bool has_copy_async): has_copy_async_(has_copy_async) {}
+  pipeline(bool has_copy_async, int num_stages)
+      : has_copy_async_(has_copy_async), num_stages_(num_stages) {}
   void run(ir::module &module);
 
 private:
   bool has_copy_async_;
+  int num_stages_;
 };
 
 } // namespace transform

--- a/include/triton/codegen/transform/prefetch.h
+++ b/include/triton/codegen/transform/prefetch.h
@@ -1,9 +1,12 @@
 #ifndef TRITON_INCLUDE_TRITON_CODEGEN_TRANSFORM_PREFETCH_H
 #define TRITON_INCLUDE_TRITON_CODEGEN_TRANSFORM_PREFETCH_H
 
+#include <set>
+
 // forward dclaration
 namespace triton::ir{
 class module;
+class value;
 }
 
 namespace triton::codegen {
@@ -13,9 +16,11 @@ class target;
 namespace triton::codegen::transform {
 class prefetch {
   target* tgt_;
+  std::set<ir::value*> prefetched_vals_;
 public:
   prefetch(target *tgt) : tgt_(tgt) {}
   void run(ir::module &module);
+  bool is_prefetched(ir::value* v) { return prefetched_vals_.find(v) != prefetched_vals_.end(); }
 };
 }
 

--- a/include/triton/ir/instructions.h
+++ b/include/triton/ir/instructions.h
@@ -832,6 +832,7 @@ public:
   static async_wait_inst* create(context &ctx, int N,
                                  const std::string &name = "", instruction *next = nullptr);
   int get_N() { return N_; }
+  void set_N(int n) { N_ = n; }
 
 private:
   int N_;

--- a/include/triton/ir/print.h
+++ b/include/triton/ir/print.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #ifndef _TRITON_IR_PRINT_H_
 #define _TRITON_IR_PRINT_H_
 
@@ -9,8 +7,14 @@ namespace triton{
 namespace ir{
 
 class module;
+class function;
+class basic_block;
+class instruction;
 
 void print(module &mod, std::ostream& os);
+void print(function &func, std::ostream& os);
+void print(basic_block &bb, std::ostream& os);
+void print(instruction &instr, std::ostream& os);
 
 }
 }

--- a/include/triton/ir/utils.h
+++ b/include/triton/ir/utils.h
@@ -17,6 +17,7 @@ class value;
 
 class cfg {
 public:
+  static std::vector<basic_block *> post_order(function* fn);
   static std::vector<basic_block *> reverse_post_order(function* fn);
 };
 

--- a/lib/codegen/analysis/layout.cc
+++ b/lib/codegen/analysis/layout.cc
@@ -7,6 +7,7 @@
 #include "triton/ir/function.h"
 #include "triton/ir/module.h"
 #include "triton/ir/utils.h"
+// #include "triton/ir/type.h"
 
 namespace triton{
 namespace codegen{
@@ -273,6 +274,74 @@ void shared_layout::extract_double_bufferable(ir::value *v, std::shared_ptr<doub
     res.reset(new double_buffer_info_t{value_1, value_0, phi});
 }
 
+static bool is_smem(ir::value* v) {
+  if (dynamic_cast<ir::copy_to_shared_inst*>(v) ||
+      dynamic_cast<ir::masked_load_async_inst*>(v))
+    return true;
+  else
+    return false;
+}
+
+static bool is_multistage_pipe_phi(ir::phi_node* phi, ir::basic_block* bb0, ir::basic_block* bb1, 
+    std::vector<ir::value*>& values_0, ir::value*& value_1) {
+  ir::value* next = phi;
+  // std::cout << "\nis_multistage_pipe_phi(...):\n";
+  // ir::print(*static_cast<ir::instruction*>(phi), std::cout);
+  while (auto cphi = dynamic_cast<ir::phi_node*>(next)) {
+    // smem from previous bb & phi/smem from current bb
+    ir::value* c0 = cphi->get_incoming_value(0);
+    ir::value* c1 = cphi->get_incoming_value(1);
+    ir::basic_block *cbb0 = cphi->get_incoming_block(0);
+    ir::basic_block *cbb1 = cphi->get_incoming_block(1);
+
+    if (is_smem(c0)) {
+      assert(cbb0 == bb0);
+      // ir::print(*static_cast<ir::instruction*>(c0), std::cout);
+      values_0.push_back(c0);
+      if (auto phi1 = dynamic_cast<ir::phi_node*>(c1)) {
+        next = phi1;
+        // ir::print(*static_cast<ir::instruction*>(c1), std::cout);
+        continue;
+      } else {
+        if (is_smem(c1)) {
+          value_1 = c1;
+          assert(cbb1 == bb1);
+          return true;
+        } else {
+          return false;
+        }
+      }
+    } else
+      return false;
+  }
+}
+
+void shared_layout::extract_N_bufferable(ir::value *v, std::shared_ptr<N_buffer_info_t> &res) {
+  auto* phi = dynamic_cast<ir::phi_node*>(v);
+  // if the phi node is nested
+  if (!phi)
+    return;
+
+  ir::basic_block *bb0 = phi->get_incoming_block(0);
+  ir::basic_block *bb1 = phi->get_incoming_block(1);
+
+  std::vector<ir::value*> values_0;
+  ir::value* value_1;
+  
+  if (!is_multistage_pipe_phi(phi, bb0, bb1, values_0, value_1))
+    return;
+
+  // compute original values_0 input order
+  std::map<ir::value*, int> order;
+  int idx = 0;
+  for (ir::instruction* instr : *bb0) {
+    if (std::find(values_0.begin(), values_0.end(), instr) != values_0.end())
+      order[static_cast<ir::value*>(instr)] = idx++;
+  }
+  assert(order.size() == values_0.size() && "order size incorrect");
+  res.reset(new N_buffer_info_t{values_0, value_1, phi, order});
+}
+
 
 shared_layout::shared_layout(data_layout *arg,
                                  const std::vector<int>& axes,
@@ -284,9 +353,16 @@ shared_layout::shared_layout(data_layout *arg,
   size_ = 0;
   arg_layout_ = arg;
 
+  // N-stage buffering
+  for (ir::value *v : values) {
+    extract_N_bufferable(v, N_buffer_);
+    if (N_buffer_) break;
+  }
+
   // double-buffering
-  for(ir::value *v: values)
-    extract_double_bufferable(v, double_buffer_);
+  if (!N_buffer_)
+    for(ir::value *v: values)
+      extract_double_bufferable(v, double_buffer_);
 
   // order
   std::vector<int> arg_order = arg ? arg->get_order() : std::vector<int>{0};
@@ -311,8 +387,22 @@ shared_layout::shared_layout(data_layout *arg,
      size_ *= s;
   if(double_buffer_)
     size_ *= 2;
+  if (N_buffer_) {
+    size_ *= (N_buffer_->firsts.size() + 1);
+  }
 }
 
+int shared_layout::get_num_stages() const {
+  if (double_buffer_)
+    return 2;
+  if (N_buffer_)
+    return N_buffer_->firsts.size() + 1;
+  return 1;
+}
+
+size_t shared_layout::get_per_stage_elements() const {
+  return get_per_stage_size()/(ty_->get_primitive_size_in_bits()/8);
+}
 
 /* -------------------------------- *
  * ---- Layouts Inference Pass ---- *
@@ -402,7 +492,6 @@ void layouts::run(ir::module &mod) {
   // create layouts
   for(const auto& x: values_)
     create(x.first, x.second);
-
 
   // create temporaries
   size_t id = values_.size();

--- a/lib/codegen/analysis/layout.cc
+++ b/lib/codegen/analysis/layout.cc
@@ -285,8 +285,6 @@ static bool is_smem(ir::value* v) {
 static bool is_multistage_pipe_phi(ir::phi_node* phi, ir::basic_block* bb0, ir::basic_block* bb1, 
     std::vector<ir::value*>& values_0, ir::value*& value_1) {
   ir::value* next = phi;
-  // std::cout << "\nis_multistage_pipe_phi(...):\n";
-  // ir::print(*static_cast<ir::instruction*>(phi), std::cout);
   while (auto cphi = dynamic_cast<ir::phi_node*>(next)) {
     // smem from previous bb & phi/smem from current bb
     ir::value* c0 = cphi->get_incoming_value(0);
@@ -329,6 +327,10 @@ void shared_layout::extract_N_bufferable(ir::value *v, std::shared_ptr<N_buffer_
   ir::value* value_1;
   
   if (!is_multistage_pipe_phi(phi, bb0, bb1, values_0, value_1))
+    return;
+
+  // double-buffer is a special case
+  if (values_0.size() == 1)
     return;
 
   // compute original values_0 input order

--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -45,20 +45,21 @@ void add_passes_to_emit_bin(ir::module &ir, driver::device *dev, int num_warps,
   codegen::analysis::liveness liveness(&layouts);
   codegen::analysis::swizzle swizzle(&layouts, target.get());
   codegen::analysis::allocation allocation(&liveness);
-  codegen::transform::membar barriers(&liveness, &layouts, &allocation, target.get());
   codegen::transform::dce dce;
   codegen::transform::peephole peephole(target.get(), &layouts);
 //  codegen::transform::reassociate reassociate;
   codegen::transform::coalesce coalesce(&align, &layouts);
   codegen::transform::prefetch prefetch_s(target.get());
+  codegen::transform::membar barriers(&liveness, &layouts, &allocation, &prefetch_s, target.get());
   codegen::generator isel(&axes, &layouts, &align, &allocation, &swizzle, target.get(), num_warps);
   // run passes
   dce.run(ir);
   peephole.run(ir);
   dce.run(ir);
+  // ir::print(ir, std::cout);
   pipeline.run(ir);
   dce.run(ir);
-  //ir::print(ir, std::cout);
+  // ir::print(ir, std::cout);
   disassociate.run(ir);
   dce.run(ir);
   align.run(ir);

--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -93,7 +93,7 @@ void add_passes_to_emit_bin(ir::module &ir, driver::device *dev, int num_warps,
   allocation.run(ir);
   prefetch_s.run(ir);
   barriers.run(ir);
-  ir::print(ir, std::cout);
+  // ir::print(ir, std::cout);
   isel.visit(ir, *llvm);
   mod = driver::module::create(dev, std::move(llvm));
   ker = driver::kernel::create(&*mod, name.c_str());

--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -26,7 +26,7 @@ namespace codegen {
 
 // TODO:
 // There should be a proper pass manager there!
-void add_passes_to_emit_bin(ir::module &ir, driver::device *dev, int num_warps,
+void add_passes_to_emit_bin(ir::module &ir, driver::device *dev, int num_warps, int num_stages,
                             driver::module *&mod, driver::kernel *&ker, size_t &shared_mem) {
   // generate llvm code
   llvm::LLVMContext ctx;
@@ -39,7 +39,7 @@ void add_passes_to_emit_bin(ir::module &ir, driver::device *dev, int num_warps,
   codegen::analysis::align align;
   codegen::analysis::axes axes;
   codegen::transform::cts cts(cts_use_async);
-  codegen::transform::pipeline pipeline(cts_use_async);
+  codegen::transform::pipeline pipeline(cts_use_async, num_stages);
   codegen::transform::disassociate disassociate;
   codegen::analysis::layouts layouts(&axes, &align, num_warps, target.get());
   codegen::analysis::liveness liveness(&layouts);

--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -93,7 +93,9 @@ void add_passes_to_emit_bin(ir::module &ir, driver::device *dev, int num_warps,
   liveness.run(ir);
   allocation.run(ir);
   prefetch_s.run(ir);
+//  ir::print(ir, std::cout);
   barriers.run(ir);
+//  ir::print(ir, std::cout);
   // ir::print(ir, std::cout);
   isel.visit(ir, *llvm);
   mod = driver::module::create(dev, std::move(llvm));

--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -93,7 +93,7 @@ void add_passes_to_emit_bin(ir::module &ir, driver::device *dev, int num_warps,
   allocation.run(ir);
   prefetch_s.run(ir);
   barriers.run(ir);
-  // ir::print(ir, std::cout);
+  ir::print(ir, std::cout);
   isel.visit(ir, *llvm);
   mod = driver::module::create(dev, std::move(llvm));
   ker = driver::kernel::create(&*mod, name.c_str());

--- a/lib/codegen/selection/generator.cc
+++ b/lib/codegen/selection/generator.cc
@@ -1362,9 +1362,6 @@ void generator::visit_mma16816(ir::dot_inst* C, ir::value *A, ir::value *B, ir::
   unsigned num_rep_0 = shapes[0] / layout->spt(0);
   unsigned num_rep_1 = shapes[1] / layout->spt(1);
 
-  std::cout << "num_rep_0: " << num_rep_0 << "\n";
-  std::cout << "num_rep_1: " << num_rep_1 << "\n";
-
   // create mma & unpack result
   auto call_mma = [&](unsigned m, unsigned n, unsigned K) {
       unsigned cols_per_thread = num_rep_0 * 2;

--- a/lib/codegen/transform/membar.cc
+++ b/lib/codegen/transform/membar.cc
@@ -20,9 +20,14 @@ namespace transform{
 int membar::group_of(ir::value* v, std::vector<ir::value*> &async_write) {
   if(ir::phi_node* phi = dynamic_cast<ir::phi_node*>(v)){
     analysis::shared_layout* layout = layouts_->get(v)->to_shared();
-    analysis::double_buffer_info_t* info = layout->get_double_buffer();
-    if(info)
+    if (analysis::double_buffer_info_t* info = layout->get_double_buffer())
       return group_of(info->first, async_write);
+    else if (analysis::N_buffer_info_t* info = layout->get_N_buffer()) {
+      if (v == info->phi)
+        return group_of(info->firsts[0], async_write);
+      else // prefetched value
+        return group_of(info->firsts[1], async_write);
+    }
     std::vector<int> groups(phi->get_num_operands());
     std::transform(phi->op_begin(), phi->op_end(), groups.begin(), [&](ir::value* v){ return group_of(v, async_write);});
     return *std::max_element(groups.begin(), groups.end());
@@ -65,6 +70,7 @@ void membar::transfer(ir::basic_block *block,
                       val_set_t& sync_read,
                       std::set<ir::value*>& safe_war,
                       bool& inserted, ir::builder& builder) {
+  std::vector<ir::async_wait_inst*> async_waits;
   ir::basic_block::inst_list_t instructions = block->get_inst_list();
   for(ir::instruction *i: instructions){
     if(dynamic_cast<ir::phi_node*>(i))
@@ -93,18 +99,20 @@ void membar::transfer(ir::basic_block *block,
         async_wait = (ir::async_wait_inst*)builder.create_async_wait(async_write.size() - 1 - N);
         barrier = (ir::barrier_inst*)builder.create_barrier();
         inserted = true;
+        async_waits.push_back(async_wait);
       }
     }
     // RAW, WAR
-    bool is_i_double_buffered = i->get_type()->is_block_ty() &&
-                                layouts_->get(i)->to_shared() &&
+    bool is_i_shared_block = i->get_type()->is_block_ty() &&
+                             layouts_->get(i)->to_shared();
+    bool is_i_double_buffered = is_i_shared_block &&
                                 layouts_->get(i)->to_shared()->get_double_buffer();
+    bool is_i_n_buffered = is_i_shared_block && 
+                           layouts_->get(i)->to_shared()->get_N_buffer();
     // WAR barrier is not required when data is double-buffered
     // TODO: how about other patterns, like WWAR?
     if(!intersect_with(read, sync_write).empty() || 
-       (!intersect_with({i}, sync_read).empty() && !is_i_double_buffered) ||
-       // force WAR barrier on A100
-       (!intersect_with({i}, sync_read).empty() && tgt_->as_nvidia()->sm() >= 80)){
+       (!intersect_with({i}, sync_read).empty() && !is_i_double_buffered && !is_i_n_buffered)) {
       builder.set_insert_point(i);
       barrier = (ir::barrier_inst*)builder.create_barrier();
       inserted = true;
@@ -120,7 +128,41 @@ void membar::transfer(ir::basic_block *block,
       sync_read.clear();
     }
     sync_read.insert(read.begin(), read.end());
+  }
 
+  // coalesce barriers
+  // fixme: to support more general cases
+  if (async_waits.size() == 2) {
+    // (aw N; bar; prefetch; aw N-1; bar; prefetch; => aw N-1; bar; 2*prefetch;)
+    for (int idx=0; idx<async_waits.size()-1; ++idx) {
+      ir::async_wait_inst *first_async_wait = async_waits[idx];
+      std::vector<ir::instruction*> to_erase;
+      ir::basic_block::inst_list_t instructions = block->get_inst_list();
+      for(auto iter = instructions.begin(); iter != instructions.end(); ++iter){
+        ir::instruction *i = *iter;
+        if (static_cast<ir::instruction*>(first_async_wait) == i) {
+          // peak next 5 instructions
+          auto peak_iter = std::next(iter);
+          if (std::distance(peak_iter, instructions.end()) >= 5) {
+            auto first_bar = dynamic_cast<ir::barrier_inst*>(*peak_iter++);
+            auto first_pf = dynamic_cast<ir::prefetch_s_inst*>(*peak_iter++);
+            auto second_async_wait = dynamic_cast<ir::async_wait_inst*>(*peak_iter++);
+            auto second_bar = dynamic_cast<ir::barrier_inst*>(*peak_iter++);
+            auto second_pf = dynamic_cast<ir::prefetch_s_inst*>(*peak_iter);
+            if (first_bar && first_pf && second_async_wait && second_bar && second_pf) {
+              int first_n = first_async_wait->get_N();
+              int second_n = second_async_wait->get_N();
+              to_erase.push_back(second_async_wait);
+              to_erase.push_back(second_bar);
+              first_async_wait->set_N(second_n);
+            }
+          } else 
+            break;
+          for (ir::instruction *i : to_erase)
+            block->erase(i);
+        }
+      }
+    }
   }
 }
 
@@ -132,7 +174,7 @@ void membar::run(ir::module &mod) {
   std::set<ir::value*> safe_war;
   for(const auto& x: layouts_->get_all()){
     analysis::shared_layout* layout = x.second->to_shared();
-    if(!layout || !layout->get_double_buffer())
+    if(!layout || !layout->get_double_buffer() || !layout->get_N_buffer())
       continue;
     for(ir::value *v: layout->get_values())
       if(v != layout->get_double_buffer()->phi){
@@ -141,7 +183,6 @@ void membar::run(ir::module &mod) {
   }
 
   for(ir::function *fn: mod.get_function_list()){
-    // TODO: (dyan) we need DominatorTree here.
     std::vector<ir::basic_block*> rpo = ir::cfg::reverse_post_order(fn);
     std::map<ir::basic_block*, val_vec_t> async_writes;
     std::map<ir::basic_block*, val_set_t> sync_writes;

--- a/lib/codegen/transform/membar.cc
+++ b/lib/codegen/transform/membar.cc
@@ -34,11 +34,24 @@ int membar::group_of(ir::value* v, std::vector<ir::value*> &async_write) {
     return *std::max_element(groups.begin(), groups.end());
   }
   else{
+    if(layouts_->has_tmp(v))
+      return async_write.size() - 1;
     auto it = std::find(async_write.begin(), async_write.end(), v);
     return std::distance(async_write.begin(), it);
   }
 }
 
+inline bool membar::intersect_with(analysis::shared_layout* a_layout, analysis::shared_layout* b_layout) {
+  if(!a_layout || !b_layout)
+    return false;
+  int a_start = alloc_->offset(a_layout);
+  int a_end = a_start + a_layout->get_size();
+  int b_start = alloc_->offset(b_layout);
+  int b_end = b_start + b_layout->get_size();
+  if(a_start < b_end || b_start < a_end)
+    return true;
+  return false;
+}
 
 membar::val_set_t membar::intersect_with(const val_set_t& as, const val_set_t& bs) {
   val_set_t ret;
@@ -46,19 +59,16 @@ membar::val_set_t membar::intersect_with(const val_set_t& as, const val_set_t& b
     if(!a->get_type()->is_block_ty())
       continue;
     analysis::shared_layout* a_layout = layouts_->get(a)->to_shared();
-    if(!a_layout)
-      continue;
-    int a_start = alloc_->offset(a_layout);
-    int a_end = a_start + a_layout->get_size();
+    analysis::shared_layout* a_tmp = layouts_->has_tmp(a) ? layouts_->get(layouts_->tmp(a))->to_shared() : nullptr;
     for(ir::value* b: bs){
       if(!b->get_type()->is_block_ty())
         continue;
       analysis::shared_layout* b_layout = layouts_->get(b)->to_shared();
-      if(!b_layout)
-        continue;
-      int b_start = alloc_->offset(b_layout);
-      int b_end = b_start + b_layout->get_size();
-      if(a_start < b_end || b_start < a_end)
+      analysis::shared_layout* b_tmp = layouts_->has_tmp(b) ? layouts_->get(layouts_->tmp(b))->to_shared() : nullptr;
+      if(intersect_with(a_layout, b_layout) ||
+         intersect_with(a_layout, b_tmp) ||
+         intersect_with(a_tmp, b_layout) ||
+         intersect_with(a_tmp, b_tmp))
         ret.insert(b);
     }
   }
@@ -108,6 +118,8 @@ void membar::transfer(ir::basic_block *block,
     std::set<ir::value*> read;
     std::copy_if(i->op_begin(), i->op_end(), std::inserter(read, read.begin()),
                  [&](ir::value* i){ return i->get_type()->is_block_ty() && layouts_->get(i)->to_shared();});
+    if(layouts_->has_tmp(i))
+      read.insert(i);
     // RAW (async)
     val_set_t tmp;
     std::copy(async_write.begin(), async_write.end(), std::inserter(tmp, tmp.begin()));

--- a/lib/codegen/transform/pipeline.cc
+++ b/lib/codegen/transform/pipeline.cc
@@ -136,7 +136,7 @@ void pipeline::run(ir::module &mod) {
   // do the pipelining
   std::vector<ir::phi_node*> new_loads;
   ir::builder &builder = mod.get_builder();
-  const int num_stages = 2;
+  const int num_stages = num_stages_;
   std::map<ir::phi_node*, std::vector<ir::value*>> preheader_loads; // Used to reorder loads
   for(auto info: to_pipeline){
     ir::load_inst* load = info.first;
@@ -148,8 +148,7 @@ void pipeline::run(ir::module &mod) {
     assert(block_br);
     assert(header_br);
     ir::type* ty = load->get_type();
-        // multi-stage pipe
-    // collect ptr offset
+    // multi-stage pipe
     if (has_copy_async_ && num_stages > 2) {
       ir::value* header_cond = header_br->get_cond();
       ir::value* block_cond = block_br->get_cond();

--- a/lib/codegen/transform/pipeline.cc
+++ b/lib/codegen/transform/pipeline.cc
@@ -23,6 +23,60 @@ void recursive_deps(ir::value* v, ir::basic_block* block, std::vector<ir::instru
    recursive_deps(u, block, ret);
 }
 
+/// assume incoming block is 1
+ir::value* rematerialize_vals(ir::builder& builder, ir::value* v, 
+                              std::map<ir::phi_node*, ir::value*>& prev_phi_vals) {
+  ir::instruction* i = dynamic_cast<ir::instruction*>(v);
+  if(!i)
+    return v;
+  if(ir::phi_node* phi = dynamic_cast<ir::phi_node*>(v)) {
+    if (prev_phi_vals.find(phi) == prev_phi_vals.end())
+      throw std::runtime_error("Don't have that phi node\n");
+    return prev_phi_vals.at(phi);
+  }
+
+  std::vector<ir::value*> new_ops;
+  for(ir::value* op: i->ops()){
+    new_ops.push_back(rematerialize_vals(builder, op, prev_phi_vals));
+  }
+  ir::instruction* ret = i->clone();
+  for(size_t k = 0; k < new_ops.size(); k++)
+    ret->set_operand(k, new_ops[k]);
+  builder.insert(ret);
+  return ret;
+}
+
+void get_induction_vars(ir::value* cond, std::set<ir::phi_node*>& phis) {
+  auto instr = dynamic_cast<ir::instruction*>(cond);
+  for (auto op : instr->ops()) {
+    if (auto phi_op = dynamic_cast<ir::phi_node*>(op)) {
+      phis.insert(phi_op);
+      return;
+    }
+    if (dynamic_cast<ir::instruction*>(op))
+      get_induction_vars(op, phis);
+  }
+}
+
+/// Returns phi_val if sees a phi node
+ir::value* rematerialize_val(ir::builder& builder, ir::value* v, ir::value* phi_val) {
+  ir::instruction* i = dynamic_cast<ir::instruction*>(v);
+  if(!i)
+    return v;
+  if(ir::phi_node* phi = dynamic_cast<ir::phi_node*>(v))
+    return phi_val;
+
+  std::vector<ir::value*> new_ops;
+  for(ir::value* op: i->ops()){
+    new_ops.push_back(rematerialize_val(builder, op, phi_val));
+  }
+  ir::instruction* ret = i->clone();
+  for(size_t k = 0; k < new_ops.size(); k++)
+    ret->set_operand(k, new_ops[k]);
+  builder.insert(ret);
+  return ret;
+}
+
 ir::value* rematerialize(ir::builder& builder, ir::value* v, size_t phi_idx){
   ir::instruction* i = dynamic_cast<ir::instruction*>(v);
   if(!i)
@@ -39,6 +93,28 @@ ir::value* rematerialize(ir::builder& builder, ir::value* v, size_t phi_idx){
     ret->set_operand(k, new_ops[k]);
   builder.insert(ret);
   return ret;
+}
+
+/// moving the prev phi vals to the next iteration
+void update_prev_phi_vals(ir::builder& builder, std::map<ir::phi_node*, ir::value*>& prev_phi_vals) {
+  for (auto& [phi, val] : prev_phi_vals) {
+    // TODO: handling nested phis
+    val = rematerialize_val(builder, phi->get_incoming_value(1), val);
+  }
+}
+
+void finalize_iv_vals(ir::builder& builder, std::map<ir::phi_node*, ir::value*>& load_ivs,
+                                            std::map<ir::phi_node*, ir::value*>& next_load_ivs) {
+  for (auto& [phi, val] : load_ivs) {
+    if (auto new_phi = dynamic_cast<ir::phi_node*>(val)) {
+      ir::value* next_k = rematerialize_vals(builder, phi->get_incoming_value(1), load_ivs);
+      assert(new_phi->get_num_operands() == 1 && "should be incomplete phi");
+      new_phi->add_incoming(next_k, phi->get_incoming_block(1));
+      // cache next_k (to be used by next_mask)
+      next_load_ivs[phi] = next_k;
+    } else
+      throw std::runtime_error("must be phi");
+  }
 }
 
 void pipeline::run(ir::module &mod) {
@@ -60,6 +136,8 @@ void pipeline::run(ir::module &mod) {
   // do the pipelining
   std::vector<ir::phi_node*> new_loads;
   ir::builder &builder = mod.get_builder();
+  const int num_stages = 3;
+  std::map<ir::phi_node*, std::vector<ir::value*>> preheader_loads; // Used to reorder loads
   for(auto info: to_pipeline){
     ir::load_inst* load = info.first;
     ir::phi_node* ptr   = info.second;
@@ -70,38 +148,112 @@ void pipeline::run(ir::module &mod) {
     assert(block_br);
     assert(header_br);
     ir::type* ty = load->get_type();
-    // pre-fetch first iteration
-    builder.set_insert_point(header->get_inst_list().back());
-    ir::value* first_ptr = ptr->get_value_for_block(header);
-    ir::value* first_mask = builder.create_splat(header_br->get_cond(), ty->get_block_shapes());
-    ir::value* false_value;
-    if(auto* masked_load = dynamic_cast<ir::masked_load_inst*>(load)){
-      ir::value* remat_mask = rematerialize(builder, masked_load->get_mask_operand(), 0);
-      ir::value* remat_false_value = rematerialize(builder, masked_load->get_false_value_operand(), 0);
-      first_mask = builder.create_and(first_mask, remat_mask);
-      false_value = remat_false_value;
+        // multi-stage pipe
+    // collect ptr offset
+    if (has_copy_async_ && num_stages > 2) {
+      ir::value* header_cond = header_br->get_cond();
+      ir::value* block_cond = block_br->get_cond();
+      // 1. collect induction variables
+      std::set<ir::phi_node*> induction_vars;
+      get_induction_vars(block_cond, induction_vars);
+
+      std::vector<ir::value*> first_ptrs(num_stages-1);
+      std::vector<ir::value*> first_loads(num_stages-1);
+      std::vector<ir::value*> first_masks(num_stages-1);
+
+      std::map<ir::phi_node*, ir::value*> prev_phi_vals;
+      // initialize prev_phi_vals
+      prev_phi_vals[ptr] = ptr->get_value_for_block(header);
+      for (ir::phi_node* iv : induction_vars)
+        prev_phi_vals[iv] = iv->get_value_for_block(header);
+      prev_phi_vals[ptr] = ptr->get_value_for_block(header);
+
+      builder.set_insert_point(header->get_inst_list().back());
+      first_ptrs[0] = ptr->get_value_for_block(header);
+      first_masks[0] = builder.create_splat(header_cond, ty->get_block_shapes());
+      ir::value* false_value = builder.create_splat(ir::undef_value::get(ty->get_scalar_ty()), ty->get_block_shapes());
+      first_loads[0] = builder.create_masked_load(first_ptrs[0], first_masks[0], false_value);
+
+      for (int stage = 1; stage < num_stages-1; ++stage) {
+        first_ptrs[stage] = rematerialize_vals(builder, ptr->get_value_for_block(block), prev_phi_vals);
+        first_masks[stage] = builder.create_splat(
+            rematerialize_vals(builder, block_cond, prev_phi_vals), ty->get_block_shapes());
+        first_loads[stage] = builder.create_masked_load(first_ptrs[stage], first_masks[stage], false_value);
+        update_prev_phi_vals(builder, prev_phi_vals);
+      }
+
+      // create new phis for induction variables
+      builder.set_insert_point(block->get_first_non_phi());
+      std::map<ir::phi_node*, ir::value*> load_ivs;
+      std::map<ir::phi_node*, ir::value*> next_load_ivs;
+      for (ir::phi_node* iv : induction_vars) {
+        ir::phi_node* pn = builder.create_phi(iv->get_type(), 2);
+        pn->add_incoming(prev_phi_vals[iv], header);
+        load_ivs[iv] = pn;
+      }
+      // add incoming for phis & update next_load_ivs
+      finalize_iv_vals(builder, load_ivs, next_load_ivs);
+        
+      // pre-fetch next iteration
+      builder.set_insert_point(block->get_inst_list().back());
+      ir::value* next_ptr = ptr->get_value_for_block(block);
+      ir::value* next_mask = builder.create_splat(
+          rematerialize_vals(builder, block_cond, load_ivs), ty->get_block_shapes());
+      ir::value* next_load = builder.create_masked_load(next_ptr, next_mask, false_value);
+
+
+      // phi node
+      ptr->set_incoming_value(0, first_ptrs.back());
+      builder.set_insert_point(block->get_first_non_phi());
+      // nested phis for load
+      std::vector<ir::phi_node*> new_load_phis(num_stages-1);
+      for (auto& pn : new_load_phis)
+        pn = builder.create_phi(ty, 2);
+      for (int i=0; i<num_stages-2; ++i) {
+        new_load_phis[i]->add_incoming(first_loads[i], header);
+        new_load_phis[i]->add_incoming(new_load_phis[i+1], block);
+      }
+      new_load_phis.back()->add_incoming(first_loads.back(), header);
+      new_load_phis.back()->add_incoming(next_load, block);
+      load->replace_all_uses_with(new_load_phis.front());
+      new_loads.push_back(new_load_phis.back());
+
+      // record first_loads to reorder them
+      preheader_loads[new_load_phis.front()] = first_loads;
+    } else {
+      // pre-fetch first iteration
+      builder.set_insert_point(header->get_inst_list().back());
+      ir::value* first_ptr = ptr->get_value_for_block(header);
+      ir::value* first_mask = builder.create_splat(header_br->get_cond(), ty->get_block_shapes());
+      ir::value* false_value;
+      if(auto* masked_load = dynamic_cast<ir::masked_load_inst*>(load)){
+        ir::value* remat_mask = rematerialize(builder, masked_load->get_mask_operand(), 0);
+        ir::value* remat_false_value = rematerialize(builder, masked_load->get_false_value_operand(), 0);
+        first_mask = builder.create_and(first_mask, remat_mask);
+        false_value = remat_false_value;
+      }
+      else
+        false_value = builder.create_splat(ir::undef_value::get(ty->get_scalar_ty()), ty->get_block_shapes());
+      ir::value* first_load = builder.create_masked_load(first_ptr, first_mask, false_value);
+      // pre-fetch next iteration
+      builder.set_insert_point(block->get_inst_list().back());
+      ir::value* next_ptr = ptr->get_value_for_block(block);
+      ir::value* next_mask = builder.create_splat(block_br->get_cond(), ty->get_block_shapes());
+      if(auto* masked_load = dynamic_cast<ir::masked_load_inst*>(load)){
+        ir::value* remat_mask = rematerialize(builder, masked_load->get_mask_operand(), 1);
+        ir::value* remat_false_value = rematerialize(builder, masked_load->get_false_value_operand(), 1);
+        next_mask = builder.create_and(next_mask, remat_mask);
+        false_value = remat_false_value;
+      }
+      ir::value* next_load = builder.create_masked_load(next_ptr, next_mask, false_value);
+      // phi node
+      builder.set_insert_point(block->get_first_non_phi());
+      ir::phi_node* new_load = builder.create_phi(ty, 2);
+      new_load->add_incoming(first_load, header);
+      new_load->add_incoming(next_load, block);
+      load->replace_all_uses_with(new_load);
+      new_loads.push_back(new_load);
     }
-    else
-      false_value = builder.create_splat(ir::undef_value::get(ty->get_scalar_ty()), ty->get_block_shapes());
-    ir::value* first_load = builder.create_masked_load(first_ptr, first_mask, false_value);
-    // pre-fetch next iteration
-    builder.set_insert_point(block->get_inst_list().back());
-    ir::value* next_ptr = ptr->get_value_for_block(block);
-    ir::value* next_mask = builder.create_splat(block_br->get_cond(), ty->get_block_shapes());
-    if(auto* masked_load = dynamic_cast<ir::masked_load_inst*>(load)){
-      ir::value* remat_mask = rematerialize(builder, masked_load->get_mask_operand(), 1);
-      ir::value* remat_false_value = rematerialize(builder, masked_load->get_false_value_operand(), 1);
-      next_mask = builder.create_and(next_mask, remat_mask);
-      false_value = remat_false_value;
-    }
-    ir::value* next_load = builder.create_masked_load(next_ptr, next_mask, false_value);
-    // phi node
-    builder.set_insert_point(block->get_first_non_phi());
-    ir::phi_node* new_load = builder.create_phi(ty, 2);
-    new_load->add_incoming(first_load, header);
-    new_load->add_incoming(next_load, block);
-    load->replace_all_uses_with(new_load);
-    new_loads.push_back(new_load);
   }
 
 

--- a/lib/codegen/transform/pipeline.cc
+++ b/lib/codegen/transform/pipeline.cc
@@ -136,7 +136,7 @@ void pipeline::run(ir::module &mod) {
   // do the pipelining
   std::vector<ir::phi_node*> new_loads;
   ir::builder &builder = mod.get_builder();
-  const int num_stages = 3;
+  const int num_stages = 2;
   std::map<ir::phi_node*, std::vector<ir::value*>> preheader_loads; // Used to reorder loads
   for(auto info: to_pipeline){
     ir::load_inst* load = info.first;

--- a/lib/codegen/transform/prefetch.cc
+++ b/lib/codegen/transform/prefetch.cc
@@ -30,8 +30,7 @@ void prefetch::run(ir::module &mod) {
   ir::for_each_instruction(mod, [&](ir::instruction *i) {
     if (auto *dot = dynamic_cast<ir::dot_inst*>(i)) {
       // Now only do prefetching when dot is fp16 & volta/turing
-      if (dot->get_operand(0)->get_type()->get_scalar_ty()->get_type_id() != ir::type::HalfTyID ||
-          tgt_->as_nvidia()->sm() >= 80)
+      if (dot->get_operand(0)->get_type()->get_scalar_ty()->get_type_id() != ir::type::HalfTyID)
         return;
       auto *a = dynamic_cast<ir::phi_node*>(dot->get_operand(0));
       auto *b = dynamic_cast<ir::phi_node*>(dot->get_operand(1));

--- a/lib/codegen/transform/prefetch.cc
+++ b/lib/codegen/transform/prefetch.cc
@@ -55,14 +55,12 @@ void prefetch::run(ir::module &mod) {
 
     // 1. in the loop header (first iteration)
     builder.set_insert_point(loop_header->get_inst_list().back());
-    builder.create_barrier();
     assert(a && b);
     builder.create_prefetch_s(a->get_incoming_value(0), /*inc*/ 0);
     builder.create_prefetch_s(b->get_incoming_value(0), /*inc*/ 0);
 
     // 2. at the end of the loop body (next iteration)
     builder.set_insert_point(loop_body->get_inst_list().back());
-    builder.create_barrier();
     builder.create_prefetch_s(a->get_incoming_value(1), /*inc*/ 1);
     builder.create_prefetch_s(b->get_incoming_value(1), /*inc*/ 1);
   }

--- a/lib/codegen/transform/prefetch.cc
+++ b/lib/codegen/transform/prefetch.cc
@@ -25,11 +25,11 @@ static void recursive_defs(ir::value *v, ir::basic_block *bb, std::vector<ir::in
 }
 
 void prefetch::run(ir::module &mod) {
-  // 1. collect dot that can be prefethced
+  // 1. collect dots that can be prefethced
   std::vector<ir::dot_inst*> to_prefetch;
   ir::for_each_instruction(mod, [&](ir::instruction *i) {
     if (auto *dot = dynamic_cast<ir::dot_inst*>(i)) {
-      // Now only do prefetching when dot is fp16 & volta/turing
+      // Now only do prefetching when dot is fp16
       if (dot->get_operand(0)->get_type()->get_scalar_ty()->get_type_id() != ir::type::HalfTyID)
         return;
       auto *a = dynamic_cast<ir::phi_node*>(dot->get_operand(0));
@@ -63,6 +63,11 @@ void prefetch::run(ir::module &mod) {
     builder.set_insert_point(loop_body->get_inst_list().back());
     builder.create_prefetch_s(a->get_incoming_value(1), /*inc*/ 1);
     builder.create_prefetch_s(b->get_incoming_value(1), /*inc*/ 1);
+
+    prefetched_vals_.insert(a->get_incoming_value(0));
+    prefetched_vals_.insert(b->get_incoming_value(0));
+    prefetched_vals_.insert(a->get_incoming_value(1));
+    prefetched_vals_.insert(b->get_incoming_value(1));
   }
 
   // move loads to the beginning of the loop

--- a/lib/driver/device.cc
+++ b/lib/driver/device.cc
@@ -98,6 +98,7 @@ int cu_device::compute_capability() const {
     return *interpreted_as_;
   size_t major = cuGetInfo<CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR>();
   size_t minor = cuGetInfo<CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR>();
+  // return 80;
   return major*10 + minor;
 }
 

--- a/lib/driver/module.cc
+++ b/lib/driver/module.cc
@@ -324,7 +324,7 @@ void cu_module::init_from_ptx(const std::string& ptx, driver::cu_device* device)
   }
   catch(exception::cuda::invalid_ptx const &){
 //#ifdef TRITON_LOG_PTX_ERROR
-    std::cout << ptx << std::endl;
+    // std::cout << ptx << std::endl;
     std::cerr << "It appears that Triton produced invalid PTX code:" << std::endl;
 //    exit(1);
 //#endif

--- a/lib/ir/print.cc
+++ b/lib/ir/print.cc
@@ -77,6 +77,54 @@ void print(module &mod, std::ostream& os) {
   }
 }
 
+void print(function &fn, std::ostream &os) {
+  //
+}
+
+void print(basic_block &bb, std::ostream &os) {
+  auto const &predecessors = bb.get_predecessors();
+  os << bb.get_name() << ":";
+  if(!predecessors.empty()){
+    os << "                 ";
+    os << "; preds = ";
+    auto const &predecessors = bb.get_predecessors();
+    for(ir::basic_block *pred: predecessors)
+      os << pred->get_name() << (pred!=predecessors.back()?", ":"");
+  }
+  os << std::endl;
+  for(ir::instruction *inst: bb.get_inst_list()){
+    print(*inst, os);
+  }
+}
+
+void print(instruction &instr, std::ostream &os) {
+    instruction *inst = &instr;
+    os << "  ";
+    if(!inst->get_type()->is_void_ty()){
+      os << instr.get_name();
+      os << " = ";
+    }
+    ir::type* type = inst->get_type();
+    os << inst->repr() << " " << type->repr();
+    ir::instruction::ops_t ops = inst->ops();
+    size_t num_ops = inst->get_num_operands();
+    if(num_ops > 0)
+      os << " ";;
+    for(unsigned i = 0; i < num_ops; i++){
+      if(auto *x = dynamic_cast<ir::constant*>(ops[i]))
+        os << x->repr();
+      else
+        os << ops[i]->get_name();
+      os << (i < num_ops - 1?", ":"");
+    }
+    os << ";";
+//        os << " (";
+//        for(ir::user* usr: inst->get_users())
+//          os << get_name(usr, cnt++) << ", " ;
+//        os << " )";
+    os << std::endl;
+}
+
 
 }
 }

--- a/lib/ir/utils.cc
+++ b/lib/ir/utils.cc
@@ -8,25 +8,39 @@
 namespace triton{
 namespace ir{
 
-std::vector<basic_block*> cfg::reverse_post_order(function* fn) {
+std::vector<basic_block*> cfg::post_order(function* fn) {
   std::stack<basic_block*> stack;
   std::set<basic_block*> visited;
   std::vector<basic_block*> result;
   // initialize stack
   for(ir::basic_block* block: fn->blocks())
-    if(block->get_predecessors().empty())
+    if(block->get_predecessors().empty()){
       stack.push(block);
+      visited.insert(block);
+    }
   // DFS
   while(!stack.empty()) {
     basic_block* current = stack.top();
-    stack.pop();
-    result.push_back(current);
-    visited.insert(current);
+    bool tail = true;
     for(basic_block* succ: current->get_successors())
-      if(visited.find(succ) == visited.end())
+      if(visited.find(succ) == visited.end()){
         stack.push(succ);
+        visited.insert(succ);
+        tail = false;
+        break;
+      }
+    if(tail){
+      stack.pop();
+      result.push_back(current);
+    }
   }
-  return std::move(result);
+  return result;
+}
+
+std::vector<basic_block*> cfg::reverse_post_order(function* fn) {
+  auto result = post_order(fn);
+  std::reverse(result.begin(), result.end());
+  return result;
 }
 
 void for_each_instruction(module &mod, const std::function<void (instruction *)> &do_work) {

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -75,11 +75,11 @@ void init_triton_driver(py::module &&m) {
 
 void init_triton_codegen(py::module &&m) {
   m.def(
-      "add_passes_to_emit_bin", [](ir::module &ir, drv::device *dev, int num_warps) {
+      "add_passes_to_emit_bin", [](ir::module &ir, drv::device *dev, int num_warps, int num_stages) {
         drv::module *mod;
         drv::kernel *ker;
         size_t shared_mem;
-        triton::codegen::add_passes_to_emit_bin(ir, dev, num_warps, mod, ker, shared_mem);
+        triton::codegen::add_passes_to_emit_bin(ir, dev, num_warps, num_stages, mod, ker, shared_mem);
         std::stringstream ss;
         ir::print(ir, ss);
         return std::make_tuple(mod, ker, shared_mem, ss.str());


### PR DESCRIPTION
Improved codegen for the Ampere GPUs.

* Make the layout pass recognize the multistage pipelined pattern.
* Now the pipeline pass can automate the multistage pipelining transformation.
* Remove extra barriers (from the prefetch pass & WAR) on Ampere.
* Update the code generator (generator.cc) to make Triton generate n-buffered shared memory loads/stores.